### PR TITLE
Use Hex representation

### DIFF
--- a/src/Exporters/ColorSetExporter.js
+++ b/src/Exporters/ColorSetExporter.js
@@ -68,13 +68,13 @@ export class ColorSetExporter {
   }
 
   colorComponents(wrapper) {
-      const color = wrapper.color()
-      return {
-          alpha: color.alpha().toFixed(3),
-          blue: color.blue().toFixed(3),
-          green: color.green().toFixed(3),
-          red: color.red().toFixed(3),
-      }
+    const hex = wrapper.hexRGBColor()
+    return {
+      alpha: wrapper.color().alpha().toFixed(3),
+      blue: "0x" + hex.slice(5, 7),
+      green: "0x" + hex.slice(3, 5),
+      red: "0x" + hex.slice(1, 3),
+    }
   }
 }
 

--- a/src/Exporters/ColorSetExporter.js
+++ b/src/Exporters/ColorSetExporter.js
@@ -46,25 +46,25 @@ export class ColorSetExporter {
   }
 
   contentsJSON(wrapper) {
-      const c = this.colorObject(wrapper)
-      return {
-          colors: [c],
-          info: {
-              author: "github.com/griffin-stewie/ColorVariablesExporter",
-              version: 1
-          }
+    const c = this.colorObject(wrapper)
+    return {
+      colors: [c],
+      info: {
+        author: "github.com/griffin-stewie/ColorVariablesExporter",
+        version: 1
       }
+    }
   }
 
   colorObject(wrapper) {
-      const color = {
-          "color-space": wrapper.colorSpaceString(),
-          components: this.colorComponents(wrapper)
-      }
-      return {
-          color: color,
-          idiom: "universal"
-      }
+    const color = {
+      "color-space": wrapper.colorSpaceString(),
+      components: this.colorComponents(wrapper)
+    }
+    return {
+      color: color,
+      idiom: "universal"
+    }
   }
 
   colorComponents(wrapper) {

--- a/src/SwatchWrapper.js
+++ b/src/SwatchWrapper.js
@@ -46,7 +46,7 @@ export class SwatchWrapper {
     }
 
     hexRGBColor() {
-        return this.swatch.color.toUpperCase().slice(0,7)
+        return this.swatch.color.toUpperCase().slice(0, 7)
     }
 
     hexRGBAColor() {


### PR DESCRIPTION
to avoid loose value  when converting floating point.